### PR TITLE
Allow indentation within strings

### DIFF
--- a/nextflow-mode.el
+++ b/nextflow-mode.el
@@ -159,11 +159,26 @@
   (defvar nextflow-font-lock-keywords
     (append nextflow--font-lock-keywords groovy-font-lock-keywords)))
 
+(defun nextflow-indent-syntax-ppss (orig-fun &rest args)
+  (let ((syntax-bol (apply orig-fun args)))
+            (setf (nth 3 syntax-bol) nil)
+            syntax-bol))
+
+(defun nextflow-indent-line ()
+  "Indent the current line according to the number of parentheses."
+  (interactive)
+  (unwind-protect
+      (progn
+        (advice-add 'syntax-ppss :around 'nextflow-indent-syntax-ppss)
+        (groovy-indent-line))
+    (advice-remove 'syntax-ppss 'nextflow-indent-syntax-ppss)))
+
 ;;;###autoload
 (define-derived-mode nextflow-mode groovy-mode "Nextflow"
   "Mode for editing Nextflow files."
   (set (make-local-variable 'font-lock-defaults)
-       (cons nextflow-font-lock-keywords (cdr font-lock-defaults))))
+       (cons nextflow-font-lock-keywords (cdr font-lock-defaults)))
+  (set (make-local-variable 'indent-line-function) #'nextflow-indent-line))
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.\\(?:nf\\)?patterns\\'" . nextflow-mode))


### PR DESCRIPTION
This PR allows for indentation within strings, so that `script` blocks can be indented. It also adds `\` as an infix character because it's frequently used to continue lines within `script` blocks.

The approach I took is hacky as hell, it just tricks `groovy-indent-line` so it doesn't know when it's inside a string. But it seems to work well enough so far...

Here's an example of a script block before/after this PR.

Before:
```
process alignReads {
    tag { sampleName }

    cpus 4

    input:
    tuple(sampleName, file(reads)) from minimap2_reads_in
    path(ref_fasta)

    output:
    tuple(sampleName, file("${sampleName}.bam")) into minimap2_bam_out

    script:
    """
minimap2 -ax sr \
-R '@RG\\tID:${sampleName}\\tSM:${sampleName}' \
${ref_fasta} ${reads} |
samtools sort -@ 2 -O bam -o ${sampleName}.bam
"""
}
```
After:
```
process alignReads {
    tag { sampleName }

    cpus 4

    input:
    tuple(sampleName, file(reads)) from minimap2_reads_in
    path(ref_fasta)

    output:
    tuple(sampleName, file("${sampleName}.bam")) into minimap2_bam_out

    script:
    """
    minimap2 -ax sr \
        -R '@RG\\tID:${sampleName}\\tSM:${sampleName}' \
        ${ref_fasta} ${reads} |
        samtools sort -@ 2 -O bam -o ${sampleName}.bam
    """
}
```